### PR TITLE
addition of minswap course submodule repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "minswap-course"]
+	path = minswap-course
+	url = https://github.com/pbwebdev/minswap-course


### PR DESCRIPTION
Pull request for the minswap-course repo has been added and this submodule should be directed to that.
https://github.com/minswap/courses/pull/2

Currently at https://github.com/pbwebdev/minswap-course

Should be https://github.com/minswap/courses/ after pull request done.

`[submodule "minswap-course"]
	path = minswap-course
	url = https://github.com/minswap/course`